### PR TITLE
feat(toolbar): #WB-1954, allow dropdown triggers to be active

### DIFF
--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -153,6 +153,10 @@ const Toolbar = forwardRef(
                     icon={item.icon}
                     type="button"
                     variant="ghost"
+                    className={clsx(
+                      item.className,
+                      item.isActive ? "is-selected" : "",
+                    )}
                   />
                 }
                 content={item.content?.()}
@@ -168,9 +172,10 @@ const Toolbar = forwardRef(
               aria-label={t(item.label)}
               variant="ghost"
               color="tertiary"
-              className={`${item.className || ""} ${
-                item.isActive ? "is-selected" : ""
-              }`}
+              className={clsx(
+                item.className,
+                item.isActive ? "is-selected" : "",
+              )}
             />
           );
         })}


### PR DESCRIPTION
# Description

La Toolbar autorise l'affichage de ses boutons en surbrillance, afin de signaler que l'action sous-jacente est activée.
Mais lorsque le bouton est un trigger de dropdown, cela ne fonctionnait pas.
Ce fix corrige simplement le problème.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
