### PR TITLE
Fix(color-picker): WB-1954, unwanted bold font, missing tooltip info, default background and text colors

### DIFF
--- a/packages/react/src/components/ColorPicker/ColorPalette.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPalette.tsx
@@ -33,6 +33,7 @@ export interface ColorPalette {
 }
 
 export const DefaultPalette: ColorPalette = {
+  className: "fw-bold",
   label: "Default palette",
   colors: [
     /* Paint It Black */

--- a/packages/react/src/components/ColorPicker/ColorPalette.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPalette.tsx
@@ -1,3 +1,5 @@
+import { TooltipProps } from "../Tooltip";
+
 export interface ColorPaletteItem {
   /**
    * CSS Color Value, in the form #AABBCC
@@ -21,7 +23,11 @@ export interface ColorPalette {
   /**
    * Description of the color palette.
    */
-  label: String;
+  label: string;
+  /**
+   * [Optional] informative tooltip.
+   */
+  tooltip?: Partial<TooltipProps>;
   /**
    * Array of colors * variations.
    */
@@ -97,6 +103,7 @@ export const DefaultPalette: ColorPalette = {
 
 export const AccessiblePalette: ColorPalette = {
   label: "Accessible palette",
+  tooltip: { message: "Veni, vidi, vici" },
   colors: [
     [{ value: "#4A4A4A", description: "color.gray" }],
     [{ value: "#648FFF", description: "color.blue" }],

--- a/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 
 import ColorPicker, { ColorPickerProps } from "./ColorPicker";
+import { useState } from "react";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof ColorPicker> = {
@@ -19,4 +20,16 @@ const meta: Meta<typeof ColorPicker> = {
 export default meta;
 type Story = StoryObj<typeof ColorPicker>;
 
-export const Base: Story = {};
+export const Template = (args: ColorPickerProps) => {
+  const [currentColor, setCurrentColor] = useState<string>("#4A4A4A");
+  const handleOnChange = (color: string) => setCurrentColor(color);
+  return (
+    <div>
+      <ColorPicker {...args} model={currentColor} onChange={handleOnChange} />
+    </div>
+  );
+};
+
+export const Base: Story = {
+  render: Template,
+};

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -44,7 +44,7 @@ const ColorPicker = ({
           className={clsx("color-picker mx-8", palette.className)}
         >
           <div className="color-picker-label small mt-4 mb-8">
-            <strong>{palette.label}</strong>
+            {palette.label}
           </div>
           <div className="color-picker-palette d-flex gap-2 justify-content-between">
             {palette.colors.map((hues: ColorPaletteHues, hueIndex) => (

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import clsx from "clsx";
 import { useTranslation } from "react-i18next";
 
@@ -33,10 +31,8 @@ const ColorPicker = ({
   onChange,
 }: ColorPickerProps) => {
   const { t } = useTranslation();
-  const [localModel, setLocalModel] = useState(model.toUpperCase());
 
   const handleClick = (color: string) => {
-    setLocalModel(color.toUpperCase());
     onChange?.(color);
   };
 
@@ -65,7 +61,7 @@ const ColorPicker = ({
                       className={clsx(
                         "color-picker-hue-color-item rounded-1",
                         color.hue === "light" ? "light" : "dark",
-                        localModel === color.value && "selected",
+                        model === color.value && "selected",
                       )}
                       style={{ backgroundColor: color.value }}
                       onClick={() => handleClick(color.value)}

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -1,3 +1,4 @@
+import { InfoCircle } from "@edifice-ui/icons";
 import clsx from "clsx";
 import { useTranslation } from "react-i18next";
 
@@ -7,6 +8,7 @@ import {
   ColorPaletteHues,
   DefaultPalette,
 } from "./ColorPalette";
+import { Tooltip } from "../Tooltip";
 
 export interface ColorPickerProps {
   /**
@@ -45,6 +47,16 @@ const ColorPicker = ({
         >
           <div className="color-picker-label small mt-4 mb-8">
             {palette.label}
+            {palette.tooltip && (
+              <Tooltip message="" placement="auto" {...palette.tooltip}>
+                <InfoCircle
+                  width={18}
+                  height={18}
+                  className="mx-4 position-relative"
+                  style={{ top: "4px" }}
+                />
+              </Tooltip>
+            )}
           </div>
           <div className="color-picker-palette d-flex gap-2 justify-content-between">
             {palette.colors.map((hues: ColorPaletteHues, hueIndex) => (


### PR DESCRIPTION
# Description

Ce fix corrige les problèmes relevés dans le ticket WB-1954 : 
* possibilité de mettre le titre d'une palette en gras ou non,
* possibilité d'ajouter, à une palette, un tooltip d'information,
* possibilité de pouvoir gérer la couleur sélectionnée en dehors du composant.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [X] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
