### PR TITLE
fix(TreeView): #WB-1978, use imperative handlers to allow selecting/d…

### DIFF
--- a/packages/react/src/components/TreeView/TreeView.tsx
+++ b/packages/react/src/components/TreeView/TreeView.tsx
@@ -128,11 +128,7 @@ const TreeView = forwardRef<TreeViewHandlers, TreeViewProps>(
       </TreeItem>
     );
 
-    return (
-      <div id="treeview" className="treeview">
-        {renderTree(data)}
-      </div>
-    );
+    return <div className="treeview">{renderTree(data)}</div>;
   },
 );
 

--- a/packages/react/src/components/TreeView/TreeView.tsx
+++ b/packages/react/src/components/TreeView/TreeView.tsx
@@ -1,7 +1,18 @@
-import { forwardRef, useEffect, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
 
 import TreeItem from "./TreeItem";
 import { TreeNode } from "./TreeNode";
+
+export interface TreeViewHandlers {
+  unselectAll: () => void;
+  select: (nodeId: string) => void;
+}
 
 export interface TreeViewProps {
   /**
@@ -44,7 +55,7 @@ export interface TreeViewProps {
  * UI TreeView Component
  */
 
-const TreeView = forwardRef<HTMLDivElement, TreeViewProps>(
+const TreeView = forwardRef<TreeViewHandlers, TreeViewProps>(
   (props: TreeViewProps, ref) => {
     const {
       data,
@@ -56,20 +67,30 @@ const TreeView = forwardRef<HTMLDivElement, TreeViewProps>(
       selectedNodesIds,
     } = props;
 
-    const [selectedItem, setSelectedItem] = useState<string>("default");
+    const [selectedItem, setSelectedItem] = useState<string | null>(null);
 
     useEffect(() => {
       if (selectedNodesIds?.length && selectedNodesIds?.length >= 1) {
         setSelectedItem(selectedNodesIds[selectedNodesIds.length - 1]);
       } else {
-        setSelectedItem("");
+        setSelectedItem(null);
       }
     }, [selectedNodesIds]);
 
-    const handleItemSelect = (nodeId: string) => {
-      setSelectedItem(nodeId);
-      onTreeItemSelect?.(nodeId);
-    };
+    const handlers: TreeViewHandlers = useMemo(
+      () => ({
+        unselectAll() {
+          setSelectedItem(null);
+        },
+        select(nodeId: string) {
+          setSelectedItem(nodeId);
+          onTreeItemSelect?.(nodeId);
+        },
+      }),
+      [onTreeItemSelect],
+    );
+
+    useImperativeHandle(ref, () => handlers, [handlers]);
 
     const handleItemFold = (nodeId: string) => {
       onTreeItemFold?.(nodeId);
@@ -95,7 +116,7 @@ const TreeView = forwardRef<HTMLDivElement, TreeViewProps>(
         section={node.section}
         selectedNodesIds={selectedNodesIds}
         selected={selectedItem === node.id}
-        onItemSelect={handleItemSelect}
+        onItemSelect={handlers.select}
         onItemFold={handleItemFold}
         onItemUnfold={handleItemUnfold}
         onItemFocus={handleItemFocus}
@@ -108,7 +129,7 @@ const TreeView = forwardRef<HTMLDivElement, TreeViewProps>(
     );
 
     return (
-      <div ref={ref} id="treeview" className="treeview">
+      <div id="treeview" className="treeview">
         {renderTree(data)}
       </div>
     );


### PR DESCRIPTION
…eselecting nodes

# Description

Workspace utilise plusieurs `TreeView` conjointement : lorsqu'on sélectionne l'une des 3, les 2 autres ne doivent plus avoir de noeud sélectionné.
Ce commit permet cela  grâce au hook `useImperativeHandle`, exportant 2 fonctions : `select(nodeId: string)` et `unselectAll()`

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
