### PR TITLE
feat(color-picker): #WB-2175, color reset option

### DIFF
--- a/packages/icons/assets/no-colors.svg
+++ b/packages/icons/assets/no-colors.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <g clip-path="url(#clip0_3054_4806)">
+    <path d="M19.1667 0H15.8334L0.833374 20H4.16671L19.1667 0Z" fill="#E13A3A"/>
+  </g>
+  <path d="M0.5 4C0.5 2.067 2.067 0.5 4 0.5H16C17.933 0.5 19.5 2.067 19.5 4V16C19.5 17.933 17.933 19.5 16 19.5H4C2.067 19.5 0.5 17.933 0.5 16V4Z" stroke="#E4E4E4"/>
+  <defs>
+    <clipPath id="clip0_3054_4806">
+      <path d="M0 4C0 1.79086 1.79086 0 4 0H16C18.2091 0 20 1.79086 20 4V16C20 18.2091 18.2091 20 16 20H4C1.79086 20 0 18.2091 0 16V4Z" fill="white"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/packages/icons/src/NoColors.tsx
+++ b/packages/icons/src/NoColors.tsx
@@ -1,0 +1,39 @@
+import type { SVGProps } from "react";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const SvgNoColors = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 20 20"
+    aria-hidden="true"
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <g clipPath="url(#no-colors_svg__a)">
+      <path fill="#E13A3A" d="M19.167 0h-3.334l-15 20h3.334l15-20Z" />
+    </g>
+    <path
+      stroke="#E4E4E4"
+      d="M.5 4A3.5 3.5 0 0 1 4 .5h12A3.5 3.5 0 0 1 19.5 4v12a3.5 3.5 0 0 1-3.5 3.5H4A3.5 3.5 0 0 1 .5 16V4Z"
+    />
+    <defs>
+      <clipPath id="no-colors_svg__a">
+        <path
+          fill="#fff"
+          d="M0 4a4 4 0 0 1 4-4h12a4 4 0 0 1 4 4v12a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V4Z"
+        />
+      </clipPath>
+    </defs>
+  </svg>
+);
+export default SvgNoColors;

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -58,6 +58,7 @@ export { default as MessageInfo } from "./MessageInfo";
 export { default as Mic } from "./Mic";
 export { default as Minus } from "./Minus";
 export { default as Move } from "./Move";
+export { default as NoColors } from "./NoColors";
 export { default as Options } from "./Options";
 export { default as OrderedList } from "./OrderedList";
 export { default as Paperclip } from "./Paperclip";

--- a/packages/react/src/components/ColorPicker/ColorPalette.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPalette.tsx
@@ -33,6 +33,10 @@ export interface ColorPalette {
    */
   colors: ColorPaletteHues[];
   /**
+   * Reset option
+   */
+  reset?: ColorPaletteItem;
+  /**
    * Optional class for styling purpose
    */
   className?: string;

--- a/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 
+import { DefaultPalette } from "./ColorPalette";
 import ColorPicker, { ColorPickerProps } from "./ColorPicker";
 import { useState } from "react";
 
@@ -20,7 +21,7 @@ const meta: Meta<typeof ColorPicker> = {
 export default meta;
 type Story = StoryObj<typeof ColorPicker>;
 
-export const Template = (args: ColorPickerProps) => {
+const Template = (args: ColorPickerProps) => {
   const [currentColor, setCurrentColor] = useState<string>("#4A4A4A");
   const handleOnChange = (color: string) => setCurrentColor(color);
   return (
@@ -32,4 +33,19 @@ export const Template = (args: ColorPickerProps) => {
 
 export const Base: Story = {
   render: Template,
+};
+
+export const Reset: Story = {
+  render: (args: ColorPickerProps) => {
+    const newArgs = {
+      ...args,
+      palettes: [
+        {
+          ...DefaultPalette,
+          reset: { value: "transparent", description: "None" },
+        },
+      ],
+    };
+    return Template(newArgs);
+  },
 };

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -1,6 +1,5 @@
-import { InfoCircle } from "@edifice-ui/icons";
+import { InfoCircle, NoColors } from "@edifice-ui/icons";
 import clsx from "clsx";
-import { useTranslation } from "react-i18next";
 
 import {
   AccessiblePalette,
@@ -32,8 +31,6 @@ const ColorPicker = ({
   model = "#4A4A4A",
   onChange,
 }: ColorPickerProps) => {
-  const { t } = useTranslation();
-
   const handleClick = (color: string) => {
     onChange?.(color);
   };
@@ -58,18 +55,35 @@ const ColorPicker = ({
               </Tooltip>
             )}
           </div>
+
+          {
+            // Show/hide the reset option
+            palette.reset && (
+              <div className="color-picker-reset small fw-normal my-8">
+                <label className="small d-flex">
+                  <button
+                    className="color-picker-hue-color-item me-4 border-0"
+                    style={{ backgroundColor: palette.reset.value }}
+                    onClick={() => handleClick(palette.reset?.value || "")}
+                  >
+                    <NoColors></NoColors>
+                  </button>
+                  {palette.reset.description}
+                </label>
+              </div>
+            )
+          }
+
           <div className="color-picker-palette d-flex gap-2 justify-content-between">
             {palette.colors.map((hues: ColorPaletteHues, hueIndex) => (
               <div
                 key={hueIndex}
-                className={clsx(
-                  "color-picker-hue d-flex gap-2 justify-content-between flex-column ",
-                )}
+                className="color-picker-hue d-flex gap-2 justify-content-between flex-column "
               >
                 {hues.map((color) => (
                   <div key={color.value} className="color-picker-hue-color">
                     <button
-                      aria-label={t(color.description)}
+                      aria-label={color.description}
                       className={clsx(
                         "color-picker-hue-color-item rounded-1",
                         color.hue === "light" ? "light" : "dark",

--- a/packages/react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.tsx
@@ -63,7 +63,9 @@ const ColorPicker = ({
                 <label className="small d-flex">
                   <button
                     className="color-picker-hue-color-item me-4 border-0"
-                    style={{ backgroundColor: palette.reset.value }}
+                    style={{
+                      backgroundColor: palette.reset?.value || "transparent",
+                    }}
                     onClick={() => handleClick(palette.reset?.value || "")}
                   >
                     <NoColors></NoColors>


### PR DESCRIPTION
# Description

Ajout d'une option pour les palettes de couleurs, affichées par le ColorPicker, qui contient la description d'une couleur de "reset" pouvant être transparent. Par défaut, le bouton affiché est _d'argent à la barre de gueules_.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [X] Icons
- [ ] Hooks

## Has the documentation changed?

- [X] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
