### PR TITLE
feat: add LoadingScreen to VideoRecorder saving

### DIFF
--- a/packages/react/src/components/LoadingScreen/LoadingScreen.stories.tsx
+++ b/packages/react/src/components/LoadingScreen/LoadingScreen.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import LoadingScreen from "./LoadingScreen";
-import React from "react";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof LoadingScreen> = {
@@ -29,13 +28,29 @@ export const Base: Story = {
 };
 
 export const Position: Story = {
-  render: (args) => <LoadingScreen />,
-
+  render: (args) => <LoadingScreen {...args} />,
+  args: {
+    position: true,
+  },
   parameters: {
     docs: {
       description: {
         story:
           "Position of the component is set to `true` per default. If set to `false`, LoadingScreen will take the whole screen and shows an overlay",
+      },
+    },
+  },
+};
+
+export const Caption: Story = {
+  render: (args) => <LoadingScreen {...args} />,
+  args: {
+    caption: "Loading...",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Caption will show text below the loading icon.",
       },
     },
   },

--- a/packages/react/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/packages/react/src/components/LoadingScreen/LoadingScreen.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 import usePaths from "../../core/usePaths/usePaths";
 
 export interface LoadingScreenProps {
-  position: boolean;
+  position?: boolean;
   caption?: string;
 }
 
@@ -17,7 +17,7 @@ const LoadingScreen = forwardRef(
     const [imagePath] = usePaths();
     const image = `${imagePath}/loading/screen-loading.gif`;
 
-    const classes = clsx(
+    const containerClasses = clsx(
       "top-0 end-0 start-0 bottom-0 d-grid justify-content-center align-content-center align-items-center z-2000",
       {
         "position-fixed": !position,
@@ -25,15 +25,17 @@ const LoadingScreen = forwardRef(
       },
     );
 
+    const captionClasses = clsx("text-center pt-12", {
+      "text-white": !position,
+    });
+
     return (
       <>
-        <div ref={ref} className={classes}>
+        <div ref={ref} className={containerClasses}>
           <div className="bg-white rounded-circle mx-auto w-25">
             <img src={image} alt="loading" />
           </div>
-          {caption && (
-            <div className="text-white text-center pt-12">{caption}</div>
-          )}
+          {caption && <div className={captionClasses}>{caption}</div>}
         </div>
         {!position && <div className="modal-backdrop fade show"></div>}
       </>

--- a/packages/react/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/packages/react/src/components/LoadingScreen/LoadingScreen.tsx
@@ -6,15 +6,19 @@ import usePaths from "../../core/usePaths/usePaths";
 
 export interface LoadingScreenProps {
   position: boolean;
+  caption?: string;
 }
 
 const LoadingScreen = forwardRef(
-  ({ position = true }: { position?: boolean }, ref: Ref<HTMLDivElement>) => {
+  (
+    { position = true, caption }: LoadingScreenProps,
+    ref: Ref<HTMLDivElement>,
+  ) => {
     const [imagePath] = usePaths();
     const image = `${imagePath}/loading/screen-loading.gif`;
 
     const classes = clsx(
-      "loading-screen top-0 end-0 start-0 bottom-0 d-grid justify-content-center align-items-center z-2000",
+      "top-0 end-0 start-0 bottom-0 d-grid justify-content-center align-content-center align-items-center z-2000",
       {
         "position-fixed": !position,
         "position-static": position,
@@ -24,9 +28,12 @@ const LoadingScreen = forwardRef(
     return (
       <>
         <div ref={ref} className={classes}>
-          <div className="bg-white rounded-circle mx-auto">
+          <div className="bg-white rounded-circle mx-auto w-25">
             <img src={image} alt="loading" />
           </div>
+          {caption && (
+            <div className="text-white text-center pt-12">{caption}</div>
+          )}
         </div>
         {!position && <div className="modal-backdrop fade show"></div>}
       </>

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -99,7 +99,7 @@ const Toolbar = forwardRef(
   ) => {
     const divToolbarRef = useRef<HTMLDivElement>();
 
-    const classes = clsx("toolbar z-2000 bg-white", className, {
+    const classes = clsx("toolbar z-1000 bg-white", className, {
       default: variant === "default",
       "no-shadow": variant === "no-shadow",
       "d-flex": isBlock,

--- a/packages/react/src/multimedia/VideoRecorder/VideoRecorder.tsx
+++ b/packages/react/src/multimedia/VideoRecorder/VideoRecorder.tsx
@@ -13,7 +13,7 @@ import { WorkspaceElement, odeServices } from "edifice-ts-client";
 import { VideoUploadParams } from "edifice-ts-client/dist/video/interface";
 import { useTranslation } from "react-i18next";
 
-import { FormControl, Label, Select } from "../../components";
+import { FormControl, Label, LoadingScreen, Select } from "../../components";
 import { Toolbar, ToolbarItem } from "../../components/Toolbar";
 import useBrowserInfo from "../../hooks/useBrowserInfo/useBrowserInfo";
 import { convertMsToMS, getBestSupportedMimeType } from "../../utils";
@@ -488,6 +488,12 @@ const VideoRecorder = ({
           className="position-absolute bottom-0 start-50 translate-middle bg-white"
         />
       </div>
+      {saving && (
+        <LoadingScreen
+          position={false}
+          caption={t("video.save.loader.caption")}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Description

Adding LoadingScreen to video saving action.

Adding caption prop to LoadingScreen component to show a caption below the loading icon.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
