### PR TITLE
[VideoRecorder] Fix #WB-1988: set video record button to danger button

### DIFF
--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -189,7 +189,7 @@ const Toolbar = forwardRef(
                 <Button
                   {...item.props}
                   key={item.name ?? index}
-                  color="tertiary"
+                  color={item.props.color ? item.props.color : "tertiary"}
                   variant="ghost"
                   tabIndex={index === 0 ? 0 : -1}
                   onKeyDown={handleKeyDown}
@@ -201,7 +201,7 @@ const Toolbar = forwardRef(
                 <IconButton
                   {...item.props}
                   key={item.name ?? index}
-                  color="tertiary"
+                  color={item.props.color ? item.props.color : "tertiary"}
                   variant="ghost"
                   tabIndex={index === 0 ? 0 : -1}
                   onKeyDown={handleKeyDown}

--- a/packages/react/src/multimedia/VideoRecorder/VideoRecorder.tsx
+++ b/packages/react/src/multimedia/VideoRecorder/VideoRecorder.tsx
@@ -378,6 +378,7 @@ const VideoRecorder = ({
       name: "record",
       props: {
         icon: <Record color={recording || recorded ? "" : "red"} />,
+        color: "danger",
         disabled: recording || recorded || saving,
         onClick: handleRecord,
       },


### PR DESCRIPTION
# Description

Set record button to danger button.

Update Toolbar component to check if toolbar item has a color prop to use it for toolbar button color, otherwise use "tertiary" as default.

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
