### PR TITLE
Fix/wb 2195: Toolbar a11y navigation between items and dropdowns 

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -26,6 +26,14 @@ export interface DropdownProps {
    * Default placement with FloatingUI
    */
   placement?: "bottom-end" | "bottom-start";
+  /**
+   * Extra keydown handler for the Dropdown Trigger.
+   * Useful for a11y keyboard navigation between a Dropdown element and other elements,
+   * for example in the Toolbar component.
+   */
+  extraTriggerKeyDownHandler?: (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) => void;
 }
 
 export type DropdownMenuOptions =
@@ -59,6 +67,7 @@ const Root = ({
   block,
   overflow = true,
   placement = "bottom-start",
+  extraTriggerKeyDownHandler,
 }: DropdownProps) => {
   const {
     visible,
@@ -68,7 +77,7 @@ const Root = ({
     itemProps,
     itemRefs,
     setVisible,
-  } = useDropdown(placement);
+  } = useDropdown(placement, extraTriggerKeyDownHandler);
 
   /* Ref to close dropdown when clicking outside */
   const ref = useClickOutside(() => setVisible(false));

--- a/packages/react/src/components/Dropdown/hooks/useDropdown.ts
+++ b/packages/react/src/components/Dropdown/hooks/useDropdown.ts
@@ -50,7 +50,12 @@ export interface UseDropdownProps {
   setVisible: Dispatch<SetStateAction<boolean>>;
 }
 
-const useDropdown = (placement: Placement | undefined): UseDropdownProps => {
+const useDropdown = (
+  placement: Placement | undefined,
+  extraTriggerKeyDownHandler?: (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) => void,
+): UseDropdownProps => {
   /* Unique Dropdown Id */
   const id = useId();
 
@@ -162,6 +167,7 @@ const useDropdown = (placement: Placement | undefined): UseDropdownProps => {
           break;
       }
 
+      extraTriggerKeyDownHandler?.(event);
       stopEvents(flag, event);
     },
     [closeDropdown, openDropdown],

--- a/packages/react/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.stories.tsx
@@ -1,7 +1,14 @@
 import { Meta, StoryObj } from "@storybook/react";
 
 import Toolbar from "./Toolbar";
-import { RecordVideo, Save, Write, Plus, Delete } from "@edifice-ui/icons";
+import {
+  RecordVideo,
+  Save,
+  Write,
+  Plus,
+  Delete,
+  Record,
+} from "@edifice-ui/icons";
 import { Dropdown } from "../Dropdown";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -230,14 +237,34 @@ export const WithPrimaryAction: Story = {
 
 export const WithDropdownAction: Story = {
   render: (args) => <Toolbar {...args} />,
-  decorators: [(Story) => <div style={{ height: "300px" }}>{Story()}</div>],
+  decorators: [
+    (Story) => (
+      <div className="m-24" style={{ height: "300px" }}>
+        {Story()}
+      </div>
+    ),
+  ],
   args: {
     items: [
       {
         type: "button",
+        name: "record",
+        props: {
+          disabled: false,
+          children: (
+            <>
+              <Record />
+              <span>Record</span>
+            </>
+          ),
+          onClick: () => console.log("on click"),
+        },
+      },
+      {
+        type: "button",
         name: "save",
         props: {
-          disabled: true,
+          disabled: false,
           children: (
             <>
               <Save />

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -1,6 +1,5 @@
 import {
   FocusEvent,
-  KeyboardEvent,
   ReactNode,
   Ref,
   forwardRef,
@@ -137,7 +136,7 @@ const Toolbar = forwardRef(
       event.target.classList.remove("focus");
     };
 
-    const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
       const index = toolbarItems.indexOf(event.currentTarget);
       switch (event.code) {
         case "ArrowLeft":
@@ -206,7 +205,11 @@ const Toolbar = forwardRef(
 
             case "dropdown":
               return (
-                <Dropdown {...item.props} key={item.name ?? index}>
+                <Dropdown
+                  {...item.props}
+                  key={item.name ?? index}
+                  extraTriggerKeyDownHandler={handleKeyDown}
+                >
                   {/* Set the children through props */}
                 </Dropdown>
               );

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -128,15 +128,11 @@ const Toolbar = forwardRef(
     }, [items]);
 
     const handleFocus = (event: FocusEvent<HTMLDivElement>) => {
-      // div toolbar
-      event.currentTarget.classList.add("focus");
       // focused button
       event.target.classList.add("focus");
     };
 
     const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
-      // div toolbar
-      event.currentTarget.classList.remove("focus");
       // focused button
       event.target.classList.remove("focus");
     };


### PR DESCRIPTION
# Description

Handle the a11y navigation with keyboard arrows between simple items and dropdowns.

https://edifice-community.atlassian.net/browse/WB-2195

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
