### PR TITLE
feat(List): #WB-2212, add generic List component

### DIFF
--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import List, { ListProps } from "./List";
+import { RefAttributes } from "react";
+
+type Item = {
+  _id: string;
+  name: string;
+  eType: string;
+  owner: string;
+};
+
+const meta: Meta<typeof List<Item>> = {
+  title: "Components/List",
+  component: List<Item>,
+  args: {
+    items: [
+      {
+        _id: "file1",
+        name: "File 1",
+        eType: "file",
+        owner: "John",
+      },
+      {
+        _id: "file2",
+        name: "File 2",
+        eType: "file",
+        owner: "Sarah",
+      },
+      {
+        _id: "file3",
+        name: "File 3",
+        eType: "file",
+        owner: "Connor",
+      },
+    ] as Item[],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof List<Item>>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+export const Base: Story = {
+  render: (args: ListProps<Item> & RefAttributes<HTMLDivElement>) => {
+    function cardRenderer(item: Item, index: number) {
+      return (
+        <>
+          A card with index={index} for {item?.name}
+        </>
+      );
+    }
+    function rowRenderer(item: Item, index: number) {
+      return (
+        <>
+          A row with index={index} for {item?.name}
+        </>
+      );
+    }
+    return (
+      <List keyField="_id" items={args.items} cardRenderer={cardRenderer} />
+    );
+  },
+};

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,0 +1,85 @@
+import { forwardRef, Key, ReactNode } from "react";
+
+import clsx from "clsx";
+
+/* `List` is a generic component that uses React.forwardRef
+ * We must redeclare the typing of forwardRef to do this nicely.
+ * @see an explanation at https://fettblog.eu/typescript-react-generic-forward-refs/
+ */
+// Local redeclaration of forwardRef
+declare module "react" {
+  function forwardRef<T, P = {}>(
+    render: (props: P, ref: React.Ref<T>) => React.ReactNode | null,
+  ): (props: P & React.RefAttributes<T>) => React.ReactNode | null;
+}
+
+/**
+ * Properties of the List component
+ */
+export interface ListProps<T> {
+  /** Items to display */
+  items: Array<T>;
+  /** Field in T to use as a React key, typically "id" */
+  keyField: keyof T;
+
+  /** Multi-selection allowed ? */
+  multiselection?: boolean;
+  /** Default renderer, if both are available. */
+  mode?: "card" | "row";
+
+  /** Empty screen displayed when no items are available. */
+  children?: ReactNode;
+
+  /** Optional class for styling purpose */
+  className?: string;
+
+  /** Items sélectionnés */
+  onChange?: (selection: Array<T>) => void;
+
+  //--- Pour le rendu par Card :
+  cardRenderer?: (item: any, index: number) => JSX.Element;
+
+  //--- Pour le rendu par Row :
+  rowRenderer?: (item: any, index: number) => JSX.Element;
+}
+
+/**
+ * List component to display items in a flex grid (Card mode) or a list (Row mode)
+ */
+function InnerList<T>(
+  { mode, ...props }: ListProps<T>,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  // If undefined, defaults to card mode
+  mode = mode ?? "card";
+  let renderer = props.cardRenderer;
+
+  // Check if row mode is available and activated
+  if (mode === "row" && typeof props.rowRenderer === "function")
+    renderer = props.rowRenderer;
+
+  // Check that at least one renderer is activated.
+  if (!renderer)
+    throw "List components must declare at least one cardRenderer or rowRenderer.";
+
+  const className = clsx("list", mode, props.className);
+
+  return (
+    <div className={className} ref={ref}>
+      {props.items.map((item, index) => {
+        return (
+          <div
+            key={item[props.keyField] as Key}
+            className={clsx(mode, index & 1 ? "even" : "odd")}
+          >
+            {renderer?.(item, index)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+InnerList.displayName = "List";
+
+export default forwardRef(InnerList);


### PR DESCRIPTION
# Description

> J'ouvre cette PR en brouillon, afin de discuter de ce composant et voir s'il vaut la peine de continuer dans cette direction.

[Ticket WB-2212](https://edifice-community.atlassian.net/browse/WB-2212)

Un début de composant `List` ayant pour finalité d'unifier les comportements.

**Fonctionnalités couvertes**
* **Mode d'affichage**
Aujourd'hui, la plupart des listes de ressources, utilisateurs, fichiers... proposent en 2 modes d'affichages : 

1. En grille, à l'aide de Cards

2. En liste, à l'aide de lignes (rows). Ce mode nécessite aussi un header

=> le composant dispose de 2 renderer distinct, et applique celui qui convient en fonction du mode choisi.
TODO: un composant List.Header pour le rendu de l'entête du mode liste.

* **Multi- ou mono-sélection**
Je pars du principe que List sert pour de l'affichage, avec la possibilité de sélectionner 1 ou plusieurs items par interaction de l'utilisateur.
=> TODO: les items sélectionnés sont transmis au parent via une callback `onChange`

Autres fonctionnalités potentielles : 

* **Filtre d'affichage des résultats** ajouter un input pour filtrer les iems affichés ?

* **Ordre de tri à l'écran** ? Serait utile.

* Lazy-loading, bouton "Voir +"... à méditer.

Pour son implémentation finale, on pourra ensuite utiliser les [classes Bootstrap dédiées](https://getbootstrap.com/docs/5.1/components/list-group/)

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [X] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
