### PR TITLE
fix(editor): #WB-2507, #WB-2523 fix linker badge selection

### DIFF
--- a/packages/editor/src/components/Renderer/LinkerRenderer.tsx
+++ b/packages/editor/src/components/Renderer/LinkerRenderer.tsx
@@ -22,7 +22,7 @@ const LinkerRenderer = ({ selected, ...props }: LinkerProps) => {
   } = props.node.attrs;
 
   const classes = clsx(
-    "align-middle badge-linker c-pointer",
+    "align-middle badge-linker c-pointer mx-4",
     className,
     selected && "bg-secondary-200",
   );
@@ -38,7 +38,7 @@ const LinkerRenderer = ({ selected, ...props }: LinkerProps) => {
   };
 
   return (
-    <NodeViewWrapper as={"span"}>
+    <NodeViewWrapper as={"span"} contentEditable="false">
       <Badge
         variant={{ type: "link" }}
         className={classes}


### PR DESCRIPTION
# Description

Tickets [WB-2507](https://edifice-community.atlassian.net/browse/WB-2507) et [WB-2523](https://edifice-community.atlassian.net/browse/WB-2523)

Le renderer du linker utilise un badge, mais en laissant son contenu éditable en mode édition. Cette PR 
+ rend le contenu non-éditable dans tous les cas,
+ Ajout d'une marge horizontale autour du badge, afin de faciliter le placement du curseur à la souris.

## Which Package changed?

Please check the name of the package you changed

- [X] Editor
- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings


[WB-2507]: https://edifice-community.atlassian.net/browse/WB-2507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-2523]: https://edifice-community.atlassian.net/browse/WB-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ