### PR TITLE
fix: #WB2-1357, fix share modal search start min length

### DIFF
--- a/packages/react/src/common/ShareModal/ShareModal.tsx
+++ b/packages/react/src/common/ShareModal/ShareModal.tsx
@@ -86,6 +86,7 @@ export default function ShareResourceModal({
     showSearchAdmlHint,
     showSearchLoading,
     showSearchNoResults,
+    getSearchMinLength,
     handleSearchInputChange,
     handleSearchResultsChange,
   } = useSearch({ resource, shareRights, shareDispatch });
@@ -231,6 +232,7 @@ export default function ShareResourceModal({
               isLoading={showSearchLoading()}
               noResult={showSearchNoResults()}
               options={searchResults}
+              searchMinLength={getSearchMinLength()}
               onSearchInputChange={handleSearchInputChange}
               onSearchResultsChange={handleSearchResultsChange}
             />

--- a/packages/react/src/common/ShareModal/hooks/useSearch.ts
+++ b/packages/react/src/common/ShareModal/hooks/useSearch.ts
@@ -20,8 +20,7 @@ type State = {
   searchInputValue: string;
   searchResults: OptionListItemType[];
   searchAPIResults: ShareSubject[];
-  searchPending: boolean;
-  isLoading: boolean;
+  isSearching: boolean;
 };
 
 type Action =
@@ -36,8 +35,7 @@ const initialState = {
   searchInputValue: "",
   searchResults: [],
   searchAPIResults: [],
-  searchPending: false,
-  isLoading: false,
+  isSearching: false,
 };
 
 function reducer(state: State, action: Action) {
@@ -45,7 +43,7 @@ function reducer(state: State, action: Action) {
     case "onChange":
       return { ...state, searchInputValue: action.payload };
     case "isSearching":
-      return { ...state, isLoading: action.payload };
+      return { ...state, isSearching: action.payload };
     case "addResult":
       return { ...state, searchResults: action.payload };
     case "addApiResult":
@@ -278,11 +276,11 @@ export const useSearch = ({
 
   const showSearchNoResults = (): boolean => {
     return (
-      (!state.searchPending &&
+      (!state.isSearching &&
         !isAdml &&
         debouncedSearchInputValue.length > 0 &&
         state.searchResults.length === 0) ||
-      (!state.searchPending &&
+      (!state.isSearching &&
         isAdml &&
         debouncedSearchInputValue.length > 3 &&
         state.searchResults.length === 0)
@@ -294,7 +292,11 @@ export const useSearch = ({
   };
 
   const showSearchLoading = (): boolean => {
-    return state.searchPending && state.searchInputValue.length > 0;
+    return state.isSearching;
+  };
+
+  const getSearchMinLength = (): number => {
+    return isAdml ? 3 : 1;
   };
 
   return {
@@ -302,6 +304,7 @@ export const useSearch = ({
     showSearchAdmlHint,
     showSearchLoading,
     showSearchNoResults,
+    getSearchMinLength,
     handleSearchInputChange,
     handleSearchResultsChange,
   };

--- a/packages/react/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/Combobox/Combobox.stories.tsx
@@ -9,7 +9,9 @@ const meta: Meta<typeof Combobox> = {
   component: Combobox,
   decorators: [(Story) => <div style={{ height: "400px" }}>{Story()}</div>],
   args: {
-    placeholder: "Saisissez 3 lettres pour démarrer la recherche",
+    searchMinLength: 1,
+    placeholder:
+      "Saisissez 'searchMinLength' lettres pour démarrer la recherche",
     options: [
       {
         value: "First Item",

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -14,6 +14,7 @@ export interface ComboboxProps
   value: string;
   isLoading: boolean;
   noResult: boolean;
+  searchMinLength?: number;
   placeholder?: string;
 }
 
@@ -39,6 +40,7 @@ const Combobox = ({
   value,
   isLoading,
   noResult,
+  searchMinLength,
   placeholder,
 }: ComboboxProps) => {
   const { t } = useTranslation();
@@ -86,6 +88,7 @@ const Combobox = ({
     <Dropdown block>
       <Combobox.Trigger
         placeholder={placeholder}
+        searchMinLength={searchMinLength}
         handleSearchInputChange={onSearchInputChange}
         value={value}
       />

--- a/packages/react/src/components/Combobox/ComboboxTrigger.tsx
+++ b/packages/react/src/components/Combobox/ComboboxTrigger.tsx
@@ -8,12 +8,14 @@ export interface ComboboxTriggerProps
   extends React.ComponentPropsWithRef<"button"> {
   handleSearchInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
   value: string;
+  searchMinLength?: number;
   placeholder?: string;
 }
 
 const ComboboxTrigger = ({
   placeholder,
   value = "",
+  searchMinLength = 3,
   handleSearchInputChange,
 }: ComboboxTriggerProps) => {
   const { triggerProps, itemProps, setVisible } = useDropdownContext();
@@ -22,7 +24,7 @@ const ComboboxTrigger = ({
     ...triggerProps,
     role: "combobox",
     onClick: () => {
-      if (value.length > 2) {
+      if (value.length >= searchMinLength) {
         setVisible(true);
       }
     },
@@ -30,8 +32,8 @@ const ComboboxTrigger = ({
   };
 
   useEffect(() => {
-    setVisible(value.length > 2);
-  }, [setVisible, value]);
+    setVisible(value.length >= searchMinLength);
+  }, [setVisible, value, searchMinLength]);
 
   return (
     <FormControl className="d-flex align-items-center" id="search">


### PR DESCRIPTION
# Description

Fix share modal search start minimum length:
- because of performance for ADML the minimum length to start the search is 3
- for non ADML the search starts with 1 character

Added a prop `searchMinLength` to `ComboboxTrigger` to pass the value of the search minimum length.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
