### PR TITLE
fix: #WB2-1334, fix space character in share modal search input

### DIFF
--- a/packages/react/src/hooks/useDropdown/useDropdown.ts
+++ b/packages/react/src/hooks/useDropdown/useDropdown.ts
@@ -210,8 +210,9 @@ const useDropdown = (
           case KEYS.Escape:
             closeDropdown();
             break;
+          // FIX WB2-1334: Space event prevents user to insert Space during search, so we comment it to keep a trace.
+          // case KEYS.Space:
           case " ":
-          case KEYS.Space:
           case KEYS.Enter:
             if (activeIndex !== -1) {
               const currentItem = Object.values(itemRefs.current)[


### PR DESCRIPTION
# Description

Space event prevents user to insert Space during search, so we comment it to keep a trace.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
