### PR TITLE
fix: #WB2-1382, show sharebookmark icon in share modal search results

### DIFF
--- a/packages/react/src/common/ShareModal/hooks/useSearch.tsx
+++ b/packages/react/src/common/ShareModal/hooks/useSearch.tsx
@@ -161,7 +161,7 @@ export const useSearch = ({
             return {
               value: searchResult.id,
               label,
-              icon: searchResult.type === "sharebookmark" ? Bookmark : null,
+              icon: searchResult.type === "sharebookmark" ? <Bookmark /> : null,
             };
           },
         );

--- a/packages/react/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/Combobox/Combobox.stories.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, useState } from "react";
 
 import { Meta, StoryObj } from "@storybook/react";
 import Combobox, { ComboboxProps } from "./Combobox";
+import { Bookmark } from "@edifice-ui/icons";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof Combobox> = {
@@ -16,6 +17,7 @@ const meta: Meta<typeof Combobox> = {
       {
         value: "First Item",
         label: "First Item",
+        icon: <Bookmark />,
       },
       {
         value: "Second Item",

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -74,6 +74,7 @@ const Combobox = ({
       <Fragment key={index}>
         <Dropdown.Item
           type="select"
+          icon={option.icon}
           onClick={() => handleOptionClick(option.value)}
         >
           {option.label}


### PR DESCRIPTION
# Description

Show sharebookmark icon in share modal search results.

Setting the icon prop to <Bookmark /> icon => I had to rename `useSearch.ts` file into `useSearch.tsx` as I am using a JSX element.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
