### PR TITLE
feat: Update badge with notification text color + notification level info

### DIFF
--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -13,6 +13,10 @@ const meta: Meta<typeof Badge> = {
       options: [
         "notification / warning",
         "notification / danger",
+        "notification / info",
+        "notification / warning / text",
+        "notification / danger / text",
+        "notification / info / text",
         "profile / student",
         "profile / teacher",
         "profile / relative",
@@ -21,6 +25,22 @@ const meta: Meta<typeof Badge> = {
       mapping: {
         "notification / warning": { type: "notification", level: "warning" },
         "notification / danger": { type: "notification", level: "danger" },
+        "notification / info": { type: "notification", level: "info" },
+        "notification / warning / text": {
+          type: "notification",
+          level: "warning",
+          color: "text",
+        },
+        "notification / danger / text": {
+          type: "notification",
+          level: "danger",
+          color: "text",
+        },
+        "notification / info / text": {
+          type: "notification",
+          level: "info",
+          color: "text",
+        },
         "profile / student": { type: "profile", profile: "student" },
         "profile / teacher": { type: "profile", profile: "teacher" },
         "profile / relative": { type: "profile", profile: "relative" },
@@ -65,6 +85,20 @@ export const VisibilityOption: Story = {
           'An empty badge is hidden by default. Set its `visibility` to `"always"` to show it anyway.',
       },
     },
+  },
+};
+
+export const NotificationTextInfoBadge: Story = {
+  args: {
+    variant: { type: "notification", level: "info", color: "text" },
+  },
+
+  render: (args: BadgeProps) => {
+    return (
+      <p>
+        Titre du billet <Badge {...args}>Brouillon</Badge>
+      </p>
+    );
   },
 };
 

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -7,7 +7,8 @@ export type BadgeRef = HTMLSpanElement;
 /** Badge variant : notification */
 export type NotificationBadgeVariant = {
   type: "notification";
-  level: "warning" | "danger";
+  level: "warning" | "danger" | "info";
+  color?: "background" | "text";
 };
 /** Badge variant : profile = teacher, student, relative or personnel */
 export type ProfileBadgeVariant = {
@@ -56,7 +57,7 @@ const Badge = forwardRef(
   (
     {
       className,
-      variant = { type: "notification", level: "danger" },
+      variant = { type: "notification", level: "danger", color: "background" },
       visibility,
       rounded,
       children,
@@ -87,7 +88,13 @@ const Badge = forwardRef(
       "always" === visibility &&
         `position-absolute translate-middle p-8 d-inline`,
 
-      "notification" === variant.type && `bg-${variant.level} text-light`,
+      "notification" === variant.type &&
+        (!variant.color || variant.color === "background") &&
+        `bg-${variant.level} text-light`,
+
+      "notification" === variant.type &&
+        variant.color === "text" &&
+        `text-${variant.level} bg-gray-200 border border-gray-400`,
 
       "profile" === variant.type && `badge-profile-${variant.profile}`,
 


### PR DESCRIPTION
# Description

Add variant options to badge's variant `Notification`. 
- level `info`
- color option `background` (default). The color from the level option will be applied on the background
- color option `text`. The color from the level option will be applied on the text color

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
